### PR TITLE
fix: concat base url with gpath without join function

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -34,7 +34,7 @@ const result = templates.map(({ path, ...item }) => {
     return {
       ...component,
       banner: `${CI_BASE_URL}/${join(gPath, banner)}`,
-      data: parse(content.replace(/__BASE__URL__/g, join(CI_BASE_URL, gPath))),
+      data: parse(content.replace(/__BASE__URL__/g, `${CI_BASE_URL}/${gPath}`)),
     };
   });
 


### PR DESCRIPTION
fixing a bug when we use the join function to concat URL with a local file URL. 