### PR TITLE
fix(docs#3683):Update qodlysource help tip url to be clickable

### DIFF
--- a/tips.json
+++ b/tips.json
@@ -281,7 +281,7 @@
   {
     "key": "editors:webform:toolbox:datasources",
     "type": "text",
-    "body": "**Qodly Sources - Managing Data on Your pages**\n\n - Explore tips regarding the Catalog and scalar Qodly Sources, each in their respective sections\n\n - For detailed information, visit https://developer.qodly.com/docs/studio/pageLoaders/qodlysources",
+    "body": "**Qodly Sources - Managing Data on Your pages**\n\n - Explore tips regarding the Catalog and scalar Qodly Sources, each in their respective sections\n\n - For detailed information, visit [qodlysources](https://developer.qodly.com/docs/studio/pageLoaders/qodlysources)",
     "video": {
       "provider": "",
       "link": ""


### PR DESCRIPTION
Closes issues:
- docs#3683